### PR TITLE
refactor: remove get_track, cache everything

### DIFF
--- a/nowplaying/__main__.py
+++ b/nowplaying/__main__.py
@@ -30,14 +30,18 @@ def start_bot() -> None:
 
 
 def main() -> None:
-    process = Process(target=start_bot)
-    process.start()
+    # Initialize the database
+    asyncio_run(db.init())
+
+    # Start the telegram bot process
+    tg_process = Process(target=start_bot)
+    tg_process.start()
 
     kw = {}
-
     if not config.is_dev_env:
         kw['workers'] = config.WEB_WORKERS
 
+    # Start the web server
     logger.info('Starting web-server...')
     run(
         'nowplaying.web_app:app', host=config.WEB_HOST, port=config.WEB_PORT,

--- a/nowplaying/bot/handlers/inline/chosen_inline_result.py
+++ b/nowplaying/bot/handlers/inline/chosen_inline_result.py
@@ -1,8 +1,10 @@
 from aiogram.enums import ParseMode
 from aiogram.types import ChosenInlineResult
+from loguru import logger
 
 from ....downloaders import download_mp3
 from ...bot import bot, dp
+from ...reporter import report_error
 from .inline import parse_inline_result_query
 from .inline_utils import UNAVAILABLE_MSG, cache_audio_and_edit, track_to_caption
 
@@ -11,14 +13,23 @@ from .inline_utils import UNAVAILABLE_MSG, cache_audio_and_edit, track_to_captio
 async def chosen_inline_result_handler(inline_result: ChosenInlineResult) -> None:
     # todo @es3n1n: multiprocess queue
     if inline_result.inline_message_id is None:
+        logger.warning('Got an update without inline message id, skipping')
         return
 
     client, track = await parse_inline_result_query(inline_result)
     if track is None or client is None:
         # :shrug:, there's nothing we can do
+        logger.error(inline_result.model_dump())
+        logger.error(f'client: {client} | track: {track}')
+        await report_error('Something unusual happened, track or client is None')
         return
 
     caption = track_to_caption(client, track, is_getter_available=True)
+
+    logger.info(
+        f'Downloading {track.artist} - {track.name} from '
+        + f'{track.platform.name}',
+    )
     thumbnail, mp3 = await download_mp3(track)
 
     if mp3 is None:

--- a/nowplaying/external/song_link.py
+++ b/nowplaying/external/song_link.py
@@ -47,6 +47,9 @@ async def _get_client() -> ClientSession:
 async def get_song_link(track_url: str, allow_fallback: bool = True) -> str | None:
     url: ParseResult = urlparse(track_url)
 
+    if 'last.fm' in track_url:
+        raise NotImplementedError()
+
     parser = get_song_link_parser(url.netloc)
     if parser:
         return parser(url)

--- a/nowplaying/models/track.py
+++ b/nowplaying/models/track.py
@@ -7,6 +7,7 @@ from ..external.apple import AppleMusicTrack
 from ..external.lastfm import LastFMTrack
 from ..external.song_link import get_song_link
 from ..util.time import TS_NULL
+from .cached_local_track import CachedLocalTrack
 from .song_link import SongLinkPlatformType
 
 
@@ -35,8 +36,18 @@ class Track(BaseModel):
 
     @property
     def is_available(self) -> bool:
-        # todo: implement the "unavailable" logic :sadge:
         return self.id is not None
+
+    @classmethod
+    async def from_cached(cls, track: CachedLocalTrack) -> 'Track':
+        return Track(
+            platform=track.platform_type,
+            artist=track.artist,
+            name=track.name,
+            id=track.id,
+            url=track.url,
+            song_link=await get_song_link(track.url),
+        )
 
     @classmethod
     async def from_spotify_item(

--- a/nowplaying/platforms/__init__.py
+++ b/nowplaying/platforms/__init__.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+from ..core.database import db
 from ..models.song_link import SongLinkPlatformType
 from ..models.track import Track
 from .abc import PlatformABC, PlatformClientABC
@@ -38,4 +39,9 @@ async def get_platform_track(
     platform_type: SongLinkPlatformType,
 ) -> Tuple[PlatformClientABC, Track | None]:
     platform = await get_platform_from_telegram_id(telegram_id, platform_type)
-    return platform, await platform.get_track(track_id)
+    cached_track = await db.get_cached_local_track_info(track_id, platform_type)
+
+    if cached_track is None:
+        return platform, None
+
+    return platform, await Track.from_cached(cached_track)

--- a/nowplaying/platforms/apple.py
+++ b/nowplaying/platforms/apple.py
@@ -10,7 +10,7 @@ from ..external.apple import AppleMusicError, AppleMusicWrapper, AppleMusicWrapp
 from ..models.song_link import SongLinkPlatformType
 from ..models.track import Track
 from ..util.exceptions import rethrow_platform_error
-from .abc import PlatformABC, PlatformClientABC
+from .abc import PlatformABC, PlatformClientABC, auto_memorize_tracks
 
 
 TYPE = SongLinkPlatformType.APPLE
@@ -31,6 +31,7 @@ class AppleClient(PlatformClientABC):
         raise NotImplementedError()
 
     @rethrow_platform_error(AppleMusicError, TYPE)
+    @auto_memorize_tracks
     async def get_current_and_recent_tracks(self, limit: int) -> AsyncIterator[Track]:
         cur_time = datetime.utcnow()
 
@@ -41,14 +42,6 @@ class AppleClient(PlatformClientABC):
                 track,
                 played_at=cur_time - timedelta(minutes=index),
             )
-
-    @rethrow_platform_error(AppleMusicError, TYPE)
-    async def get_track(self, track_id: str) -> Track | None:
-        track_info = await self.app.get_track(track_id)
-        if track_info is None:
-            return None
-
-        return await Track.from_apple_item(track_info)
 
     async def add_to_queue(self, track_id: str) -> bool:
         return True


### PR DESCRIPTION
might be a wip for a long time, here are some thoughts:
- Searcher that is made for last.fm should be rewritten, should probably also add a few more platforms to the searching algorithm (itunes/yandex)
- Since we're now caching every track in the database, before merging we have to add a cron task to remove tracks older than 30 days (or 90 days, wtv). But I think we have to store old last.fm tracks too since we're generating ids for them by ourselves
- We should probably cache the song.link in a database too (to make last.fm caching work with the new caching)

Migration:
```sql
ALTER TABLE local_tracks
ALTER COLUMN id TYPE VARCHAR,
ALTER COLUMN id SET DEFAULT gen_random_uuid()::VARCHAR;

ALTER TABLE local_tracks
DROP CONSTRAINT local_tracks_pkey;

ALTER TABLE local_tracks
ALTER COLUMN id DROP DEFAULT;
```